### PR TITLE
#9 Add Better Code Hub badge to user readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 [![codecov](https://codecov.io/gh/smf541/PK-Group5/branch/master/graph/badge.svg)](https://codecov.io/gh/smf541/PK-Group5)
 
+[![BCH compliance](https://bettercodehub.com/edge/badge/smf541/PK-Group5?branch=master)](https://bettercodehub.com/)
+
 starter pk modelling repository


### PR DESCRIPTION
Solves issue #9: Better Code Hub score is now visible at top of user readme. 