### PR TITLE
Fix syntax error by changing variable names from strings

### DIFF
--- a/usage.py
+++ b/usage.py
@@ -4,7 +4,7 @@
 import pkmodel as pk
 
 
-model1 = pk.model( 'name', 'V_c'=1.0, 'CL'=1.0, 'X'=1.0, 'Ka_q0'=1.0 )
+model1 = pk.model( name, V_c=1.0, CL=1.0, X=1.0, Ka_q0=1.0 )
 model1.name
 model1.add_compartment( Q_p, V_p )
 model1.list()
@@ -21,8 +21,8 @@ model1_args = {
     'X': 1.0,
 }
 
-proto1 = pk.protocol( 'type', dose, t_eval, y0 )
-proto1.type
+proto1 = pk.protocol( proto_type, dose, t_eval, y0 )
+proto1.proto_type
 proto1.dose()
 ...
 


### PR DESCRIPTION
Changed variable names in usage.py from strings to fix syntax error. Renamed type to proto_type to avoid confusion with type variable property.