### PR TITLE
Added getter and setter functionality to Protocol's dosage function.

### DIFF
--- a/pkmodel/protocol.py
+++ b/pkmodel/protocol.py
@@ -19,6 +19,8 @@ class Protocol:
             raise TypeError('time_span must be int or float')
         self.__Initial_dose = initial_dose
         self.__Time_span = time_span
+        # define the default dose function to be f(t,y)=0
+        self.__Dose_func = lambda t, y: 0
 
     @property
     def name(self) -> str:
@@ -50,29 +52,31 @@ class Protocol:
     # now want a method where the user can access the dose(t)
     # function, which describes the rate of input of the drug over time
 
-    def dose(self, time=None, func=None):
-        # we assume the default case is the instantaneous injection,
-        # and so time doesn't need to be specified by the user, thus
-        # by default we set it to None
+    @property
+    def dose(self):
         """
-        Function describing the rate of drug input over time
+        Returns the function describing rate of drug input over time
+        """
+        return self.__Dose_func
+        # default case is the instantaneous addition, in which
+        # case, there is no further addition, and rate is 0
+
+    def add_dose_function(self, func=None):
+        """
+        Allows the user to specify the function describing 
+        rate of drug input over time
 
         Parameters
         ----------
-        time: float, time variable for the simulation, set to None by default
         func: function, function describing the rate of drug input over time,
         set to None by default
 
         Returns
         -------
-        dose(y, t): function
+        dose(t, y): function
         """
 
         if func is not None:
             # we need a way to test that func is dependent on time and y
-            func(1, 2)  # Test that is accepts two arguments
-            return func
-        else:
-            return lambda y, t: 0
-            # default case is the instantaneous addition, in which
-            # case, there is no further addition, and rate is 0
+            func(1, 2)  # Test that it accepts two arguments
+            self.__Dose_func = func

--- a/pkmodel/protocol.py
+++ b/pkmodel/protocol.py
@@ -63,7 +63,7 @@ class Protocol:
 
     def add_dose_function(self, func=None):
         """
-        Allows the user to specify the function describing 
+        Allows the user to specify the function describing
         rate of drug input over time
 
         Parameters

--- a/pkmodel/tests/test_protocol.py
+++ b/pkmodel/tests/test_protocol.py
@@ -70,10 +70,10 @@ class ProtocolTest(unittest.TestCase):
         Tests Protocol dose function creation.
         """
         protocol = pk.Protocol()
-        dose = protocol.dose()
+        dose = protocol.dose
         self.assertEqual(str(type(dose)), "<class 'function'>")
         dose_func_in = lambda y, t: 0
-        dose_func_out = protocol.dose(func=dose_func_in)
+        dose_func_out = dose(func=dose_func_in)
         self.assertEqual(dose_func_in, dose_func_out)
         with self.assertRaises(TypeError):
             dose_func = lambda z: 0

--- a/pkmodel/tests/test_protocol.py
+++ b/pkmodel/tests/test_protocol.py
@@ -74,8 +74,8 @@ class ProtocolTest(unittest.TestCase):
         dose = protocol.dose
         self.assertEqual(str(type(dose)), "<class 'function'>")
         dose_func_in = lambda y, t: 0
-        dose_func_out = dose(func=dose_func_in)
+        dose_func_out = protocol.add_dose_function(func=dose_func_in)
         self.assertEqual(dose_func_in, dose_func_out)
         with self.assertRaises(TypeError):
             dose_func = lambda z: 0
-            protocol.dose(func=dose_func)
+            protocol.add_dose_function(func=dose_func)

--- a/pkmodel/tests/test_protocol.py
+++ b/pkmodel/tests/test_protocol.py
@@ -74,7 +74,8 @@ class ProtocolTest(unittest.TestCase):
         dose = protocol.dose
         self.assertEqual(str(type(dose)), "<class 'function'>")
         dose_func_in = lambda y, t: 0
-        dose_func_out = protocol.add_dose_function(func=dose_func_in)
+        protocol.add_dose_function(func=dose_func_in)
+        dose_func_out = protocol.dose
         self.assertEqual(dose_func_in, dose_func_out)
         with self.assertRaises(TypeError):
             dose_func = lambda z: 0


### PR DESCRIPTION
Added getter method Protocol.dose - accesses dose(t) function, name 'dose' preserved so as not to break new Solution methods. 
Added setter method add_dosage_function - allows the user to alter the dose(t) function by passing a new function. 

Closes #67. 